### PR TITLE
Rearranging post processing and merging of samples

### DIFF
--- a/examples/api_test.cpp
+++ b/examples/api_test.cpp
@@ -82,5 +82,14 @@ int main(int argc, char **argv)
     matmul(N,a,b,c);
     Mitos_end_sampler();
     std::set<std::string> src_files;
-    Mitos_post_process(argv[0],&mout, src_files);
+    Mitos_add_offsets("", &mout);
+    if(Mitos_openFile(argv[0], &mout))
+    {
+        std::cerr << "Error opening binary file!" << std::endl;
+        return 1;
+    }
+    if(Mitos_post_process(argv[0],&mout, src_files)){
+        std::cerr << "Error post processing!" << std::endl;
+        return 1;
+    }
 }

--- a/examples/api_test.cpp
+++ b/examples/api_test.cpp
@@ -81,6 +81,6 @@ int main(int argc, char **argv)
     Mitos_begin_sampler();
     matmul(N,a,b,c);
     Mitos_end_sampler();
-
-    Mitos_post_process(argv[0],&mout);
+    std::set<std::string> src_files;
+    Mitos_post_process(argv[0],&mout, src_files);
 }

--- a/inputs/input.txt
+++ b/inputs/input.txt
@@ -1,3 +1,0 @@
-bin_name = /u/home/mishrad/mitos-master/inst-dir/bin/lulesh2.0
-dir_path = /u/home/mishrad/mitos-master/inst-dir/bin
-dir_prefix = 1709056761_openmp_distr_monresult

--- a/inputs/input.txt
+++ b/inputs/input.txt
@@ -1,4 +1,3 @@
 bin_name = /u/home/mishrad/mitos-master/inst-dir/bin/lulesh2.0
 dir_path = /u/home/mishrad/mitos-master/inst-dir/bin
-dir_prefix = 1709056761_openmp_distr_mon
-dir_first_dir_prefix = 1709056761_openmp_distr_mon_734783
+dir_prefix = 1709056761_openmp_distr_monresult

--- a/src/Mitos.h
+++ b/src/Mitos.h
@@ -65,6 +65,7 @@ int Mitos_create_output(struct mitos_output *mout, const char *prefix_name);
 int Mitos_pre_process(struct mitos_output *mout);
 int Mitos_set_result_mout(mitos_output *mout, const char *prefix_name);
 int Mitos_write_sample(struct perf_event_sample *s, struct mitos_output *mout);
+int Mitos_add_offsets(const char * virt_address, mitos_output *mout);
 int Mitos_openFile(const char *bin_name, mitos_output *mout);
 int Mitos_post_process(const char *bin_name, mitos_output *mout, std::set<std::string>& src_files);
 int Mitos_merge_files(const std::string& dir_prefix, const std::string& dir_first_dir);

--- a/src/Mitos.h
+++ b/src/Mitos.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include <set>
+#include <map>
 #include "ibs_types.h"
 
 // Define verbosity levels
@@ -69,6 +70,7 @@ int Mitos_add_offsets(const char * virt_address, mitos_output *mout);
 int Mitos_openFile(const char *bin_name, mitos_output *mout);
 int Mitos_post_process(const char *bin_name, mitos_output *mout, std::set<std::string>& src_files);
 int Mitos_merge_files(const std::string& dir_prefix, const std::string& dir_first_dir);
+int Mitos_modify_samples(const std::string& dir_prefix, const std::map<std::string, std::string>& path_replacements);
 int Mitos_copy_sources(const std::string& dir_prefix, const std::set<std::string>& src_files);
 #ifdef __cplusplus
 } // extern "C"

--- a/src/Mitos.h
+++ b/src/Mitos.h
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
+#include <set>
 #include "ibs_types.h"
 
 // Define verbosity levels
@@ -62,9 +63,12 @@ long Mitos_z_index(struct perf_event_sample *s);
 // Output
 int Mitos_create_output(struct mitos_output *mout, const char *prefix_name);
 int Mitos_pre_process(struct mitos_output *mout);
+int Mitos_set_result_mout(mitos_output *mout, const char *prefix_name);
 int Mitos_write_sample(struct perf_event_sample *s, struct mitos_output *mout);
-int Mitos_post_process(const char *bin_name, struct mitos_output *mout);
+int Mitos_openFile(const char *bin_name, mitos_output *mout);
+int Mitos_post_process(const char *bin_name, mitos_output *mout, std::set<std::string>& src_files);
 int Mitos_merge_files(const std::string& dir_prefix, const std::string& dir_first_dir);
+int Mitos_copy_sources(const std::string& dir_prefix, const std::set<std::string>& src_files);
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -11,8 +11,6 @@
 #include "Mitos.h"
 #include <vector>
 #include <cstdlib>
-#include <omp.h>
-#include <set>
 
 #ifndef __has_include
 static_assert(false, "__has_include not supported");
@@ -54,30 +52,21 @@ void openInputFile (std::ifstream &inputFile, std::string &bin_name, std::string
 int main(int argc, char* argv[])
 {
     // Check if input file is provided as command-line argument
-    if (argc != 2) {
-        std::cerr << "Usage: " << argv[0] << " <input_file>\n";
-        return 1;
-    }
-
-    // Open the input file
-    std::ifstream inputFile(argv[1]);
-
-    // Check if the file is opened successfully
-    if (!inputFile.is_open()) {
-        std::cerr << "Error opening file\n";
+    if (argc != 3) {
+        std::cerr << "Usage: " << argv[0] << " <Executable path> <Name of Results Directory> \n";
+        std::cerr << "For example: ./demo_post_process /u/home/ubuntu/bin/matmul 1710533830_openmp_distr_monresult \n";
         return 1;
     }
 
     // Variables to store values
-    std::string bin_name, dir_path, dir_prefix;
-    openInputFile(inputFile, bin_name, dir_path,
-            dir_prefix);
-    
+    std::string bin_name, dir_prefix;
     // Output the variables
-    std::cout << "bin_name: " << bin_name << '\n';
-    std::cout << "dir_path: " << dir_path << '\n';
-    std::cout << "dir_prefix: " << dir_prefix << '\n';
-    std::string output_dirs = dir_path + std::string("/") + dir_prefix;
+    bin_name = argv[1];
+    dir_prefix = argv[2];
+    
+    std::cout << "Executable Name: " << bin_name << '\n';
+    std::cout << "Results directory: " << dir_prefix << '\n';
+    std::string output_dirs = dir_prefix;
     
     Mitos_set_result_mout(&mouts, output_dirs.c_str());    
     Mitos_openFile(bin_name.c_str(), &mouts);

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -51,16 +51,6 @@ int sym_success = 0;
 void openInputFile (std::ifstream &inputFile, std::string &bin_name, std::string &dir_path,
             std::string &dir_prefix);
 
-int process_mout(mitos_output *mout, const char *prefix_name);
-
-void demo_write_samples_header(std::ofstream& fproc);
-
-int demo_openFile(const char *bin_name, mitos_output *mout);
-
-int demo_post_process(const char *bin_name, mitos_output *mout, std::set<std::string>& src_files);
-
-int copy_source_files(const std::string& dir_prefix, const std::set<std::string>& src_files);
-
 int main(int argc, char* argv[])
 {
     // Check if input file is provided as command-line argument
@@ -89,12 +79,12 @@ int main(int argc, char* argv[])
     std::cout << "dir_prefix: " << dir_prefix << '\n';
     std::string output_dirs = dir_path + std::string("/") + dir_prefix;
     
-    process_mout(&mouts, output_dirs.c_str());    
-    demo_openFile(bin_name.c_str(), &mouts);
+    Mitos_set_result_mout(&mouts, output_dirs.c_str());    
+    Mitos_openFile(bin_name.c_str(), &mouts);
     
     std::set<std::string> src_files;
 
-    demo_post_process(bin_name.c_str(), &mouts, src_files);
+    Mitos_post_process(bin_name.c_str(), &mouts, src_files);
 
     std::cout << "Following source files found:\n";
     for (auto& str : src_files) {
@@ -104,7 +94,8 @@ int main(int argc, char* argv[])
     /* Examples:
     dir:prefix: 1708705259_openmp_distr_monresult
     */
-    copy_source_files(dir_prefix, src_files);
+    //copy_source_files(dir_prefix, src_files);
+    Mitos_copy_sources(dir_prefix, src_files);
 }
 
 void openInputFile (std::ifstream &inputFile, std::string &bin_name, std::string &dir_path,
@@ -138,247 +129,4 @@ void openInputFile (std::ifstream &inputFile, std::string &bin_name, std::string
                 dir_prefix = value;
         }
     }
-}
-
-int process_mout(mitos_output *mout, const char *prefix_name)
-{
-    memset(mout,0,sizeof(struct mitos_output));
-
-    // Set top directory name
-    std::stringstream ss_dname_topdir;
-    //ss_dname_topdir << prefix_name << "_" << std::time(NULL);
-    ss_dname_topdir << prefix_name;
-    mout->dname_topdir = strdup(ss_dname_topdir.str().c_str());
-
-    // Set data directory name
-    std::stringstream ss_dname_datadir;
-    ss_dname_datadir << ss_dname_topdir.str() << "/data";
-    mout->dname_datadir = strdup(ss_dname_datadir.str().c_str());
-
-    // Set src directory name
-    std::stringstream ss_dname_srcdir;
-    ss_dname_srcdir << ss_dname_topdir.str() << "/src";
-    mout->dname_srcdir = strdup(ss_dname_srcdir.str().c_str());
-
-    // Set hwdata directory name
-    std::stringstream ss_dname_hwdatadir;
-    ss_dname_hwdatadir << ss_dname_topdir.str() << "/hwdata";
-    mout->dname_hwdatadir = strdup(ss_dname_hwdatadir.str().c_str());
-
-    mout->fname_raw = strdup(std::string(std::string(mout->dname_datadir) + "/raw_samples.csv").c_str());
-    mout->fname_processed = strdup(std::string(std::string(mout->dname_datadir) + "/samples.csv").c_str());
-
-    return 0;
-}
-
-
-void demo_write_samples_header(std::ofstream& fproc) {
-    // Write header for processed samples
-    fproc << "source,line,instruction,bytes,offset,ip,variable,buffer_size,dims,xidx,yidx,zidx,pid,tid,time,addr,cpu,latency,";
-#if !defined(USE_IBS_FETCH) && !defined(USE_IBS_OP)
-    fproc << "level,hit_type,op_type,snoop_mode,tlb_access,";
-#endif
-    fproc << "numa";
-#ifdef USE_IBS_FETCH
-    fproc << ",ibs_fetch_max_cnt,ibs_fetch_cnt,ibs_fetch_lat,ibs_fetch_en,ibs_fetch_val,ibs_fetch_comp,ibs_ic_miss,ibs_phy_addr_valid,ibs_l1_tlb_pg_sz,ibs_l1_tlb_miss,ibs_l2_tlb_miss,ibs_rand_en,ibs_fetch_l2_miss,";
-    fproc << "ibs_fetch_lin_addr,ibs_fetch_phy_addr,ibs_fetch_control_extended";
-#endif // USE_IBS_FETCH
-#ifdef USE_IBS_OP
-    fproc << ",ibs_op_max_cnt,ibs_op_en,ibs_op_val,ibs_op_cnt_ctl,ibs_op_max_cnt_upper,ibs_op_cur_cnt,";
-        fproc << "ibs_op_rip,";
-        // ibs_op_data_1
-        fproc << "ibs_comp_to_ret_ctr,ibs_tag_to_ret_ctr,ibs_op_brn_resync,ibs_op_misp_return,ibs_op_return,ibs_op_brn_taken,ibs_op_brn_misp,";
-        fproc << "ibs_op_brn_ret,ibs_rip_invalid,ibs_op_brn_fuse,ibs_op_microcode,";
-        // ibs_op_data_2
-        fproc << "ibs_nb_req_src,ibs_nb_req_dst_node,ibs_nb_req_cache_hit_st,";
-        // ibs_op_data_3
-        fproc << "ibs_ld_op,ibs_st_op,ibs_dc_l1_tlb_miss,ibs_dc_l2_tlb_miss,ibs_dc_l1_tlb_hit_2m,ibs_dc_l1_tlb_hit_1g,ibs_dc_l2_tlb_hit_2m,";
-        fproc << "ibs_dc_miss,ibs_dc_miss_acc,ibs_dc_ld_bank_con,ibs_dc_st_bank_con,ibs_dc_st_to_ld_fwd,ibs_dc_st_to_ld_can,";
-        fproc << "ibs_dc_wc_mem_acc,ibs_dc_uc_mem_acc,ibs_dc_locked_op,ibs_dc_no_mab_alloc,ibs_lin_addr_valid,ibs_phy_addr_valid,";
-        fproc << "ibs_dc_l2_tlb_hit_1g,ibs_l2_miss,ibs_sw_pf,ibs_op_mem_width,ibs_op_dc_miss_open_mem_reqs,ibs_dc_miss_lat,ibs_tlb_refill_lat,";
-        // lin and phy address
-        fproc << "ibs_op_phy,ibs_op_lin,";
-        // ibs brs target address
-        fproc << "ibs_branch_target";
-#endif // USE_IBS_OP
-    fproc << "\n";
-}
-
-int demo_openFile(const char *bin_name, mitos_output *mout)
-{
-// Open input/output files
-std::ifstream fraw(mout->fname_raw);
-std::ofstream fproc(mout->fname_processed);
-#ifndef USE_DYNINST
-    // No Dyninst, no post-processing
-    err = rename(mout->fname_raw, mout->fname_processed);
-    if(err)
-    {
-        std::cerr << "Mitos: Failed to rename raw output to " << mout->fname_processed << std::endl;
-    }
-
-    fproc.close();
-    fraw.close();
-
-    return 0;
-#else // USE DYNINST
-
-    std::cout << "demo.cpp, demo_openFile(), bin_name: " << bin_name << "\n";
-    sym_success = SymtabAPI::Symtab::openFile(symtab_obj,bin_name);
-    std::cout << "demo.cpp, demo_openFile(), sym_success: " << sym_success <<"\n";
-    if(!sym_success)
-    {
-        std::cerr << "Mitos: Failed to open Symtab object for " << bin_name << std::endl;
-        std::cerr << "Saving raw data (no source/instruction attribution)" << std::endl;
-
-        fraw.close();
-        fproc.close();
-
-        int err = rename(mout->fname_raw, mout->fname_processed);
-        if(err)
-        {
-            std::cerr << "Mitos: Failed to rename raw output to " << mout->fname_processed << std::endl;
-        }
-        return 1;
-    }
-    return 0;
-}
-
-int demo_post_process(const char *bin_name, mitos_output *mout, std::set<std::string>& src_files)
-{
-    int err = 0;
-    // Open input/output files
-    std::cout <<"mout->fname_raw: " <<mout->fname_raw << "\n";
-    std::ifstream fraw(mout->fname_raw);
-    std::ofstream fproc(mout->fname_processed);
-    
-    symtab_code_src = new SymtabCodeSource(strdup(bin_name));
-
-    // Get machine information
-    unsigned int inst_length = InstructionDecoder::maxInstructionLength;
-    Architecture arch = symtab_obj->getArchitecture();
-
-    demo_write_samples_header(fproc);
-
-    //get base (.text) virtual address of the measured process
-    long long offsetAddr = 0;
-    std::string str_offset;
-    // Read raw samples one by one and get attribute from ip
-    Dyninst::Offset ip;
-    std::string line, ip_str;
-    int tmp_line = 0;
-    LOG_MEDIUM("demo.cpp:demo_post_process(), reading raw samples...");
-
-    while(std::getline(fraw, line).good())
-    {
-        // Unknown values
-        std::string source;
-        std::stringstream line_num;
-        std::stringstream instruction;
-        std::stringstream bytes;
-
-        // Extract offset     
-        size_t offset_endpos = line.find(',');
-        str_offset = line.substr(0,offset_endpos);
-        offsetAddr = strtoll(str_offset.c_str(),NULL,0);
-        // Extract ip
-        size_t ip_endpos = (line.substr(offset_endpos+1)).find(',');
-        std::string ip_str = line.substr(offset_endpos+1,ip_endpos);
-        ip = (Dyninst::Offset)(strtoull(ip_str.c_str(),NULL,0) - offsetAddr);
-        if(tmp_line%4000==0)
-            std::cout << "ip: " << ip <<"\n";
-        // Parse ip for source line info
-        std::vector<SymtabAPI::Statement::Ptr> stats;
-        sym_success = symtab_obj->getSourceLines(stats, ip);
-
-        if(sym_success)
-        {
-            source = (string)stats[0]->getFile();
-            if (!mout->dname_srcdir_orig.empty())
-            {
-                std::size_t pos = source.find(mout->dname_srcdir_orig);
-                if(pos == 0){
-                    source = source.substr(mout->dname_srcdir_orig.length() + (mout->dname_srcdir_orig.back() == '/' ? 0 : 1)); //to remove slash if there is none in the string
-                }
-
-            }
-            line_num << stats[0]->getLine();
-        }
-        if(!source.empty()){
-            src_files.insert(source);
-        }
-
-        // Parse ip for instruction info
-        void *inst_raw = NULL;
-        if(symtab_code_src->isValidAddress(ip))
-        {
-            inst_raw = symtab_code_src->getPtrToInstruction(ip);
-
-            if(inst_raw)
-            {
-                // Get instruction
-                InstructionDecoder dec(inst_raw,inst_length,arch);
-                Instruction inst = dec.decode();
-                Operation op = inst.getOperation();
-                entryID eid = op.getID();
-
-                instruction << NS_x86::entryNames_IAPI[eid];
-
-                // Get bytes read
-                if(inst.readsMemory())
-                    bytes << getReadSize(inst);
-            }
-        }
-        LOG_HIGH("demo.cpp:demo_post_process(), writing out sample no. " << tmp_line + 1);
-        // Write out the sample
-        fproc << (source.empty()            ? "??" : source             ) << ","
-              << (line_num.str().empty()    ? "??" : line_num.str()     ) << ","
-              << (instruction.str().empty() ? "??" : instruction.str()  ) << ","
-              << (bytes.str().empty()       ? "??" : bytes.str()        ) << ","
-              << line << std::endl;
-
-        tmp_line++;
-    }
-    fraw.close();
-    fproc.close();
-
-
-    err = remove(mout->fname_raw);
-    if(err)
-    {
-        std::cerr << "Mitos: Failed to delete raw sample file!\n";
-        return 1;
-    }
-
-#endif // USE_DYNINST
-
-    return 0;
-}
-
-
-int copy_source_files(const std::string& dir_prefix, const std::set<std::string>& src_files) {
-    
-    std::string path_dir_result = "./"+ dir_prefix;
-    // copy source files
-
-    std::cout << "Copying source files to result folder...\n";
-    std::string path_src_dir = path_dir_result + "/src";
-    for (auto& src_file : src_files) {
-        try {
-            // Check if source file exists
-            if (!fs::exists(src_file)) {
-                std::cerr << "Source file not accessible: " << src_file << "\n";
-            }
-
-            // Copy the file
-            fs::copy(src_file, path_src_dir);
-
-            std::cout << "File copied successfully." << "\n";
-        } catch (const std::exception& ex) {
-            std::cerr << "Error: " << ex.what() << "\n";
-        }   
-    }
-    
-    std::cout << "Merge successfully completed\n";
-    return 0;
 }

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -46,9 +46,6 @@ SymtabAPI::Symtab *symtab_obj;
 SymtabCodeSource *symtab_code_src;
 int sym_success = 0;
 
-void openInputFile (std::ifstream &inputFile, std::string &bin_name, std::string &dir_path,
-            std::string &dir_prefix);
-
 int main(int argc, char* argv[])
 {
     // Check if input file is provided as command-line argument
@@ -66,9 +63,8 @@ int main(int argc, char* argv[])
     
     std::cout << "Executable Name: " << bin_name << '\n';
     std::cout << "Results directory: " << dir_prefix << '\n';
-    std::string output_dirs = dir_prefix;
     
-    Mitos_set_result_mout(&mouts, output_dirs.c_str());    
+    Mitos_set_result_mout(&mouts, dir_prefix.c_str());    
     Mitos_openFile(bin_name.c_str(), &mouts);
     
     std::set<std::string> src_files;
@@ -80,42 +76,5 @@ int main(int argc, char* argv[])
         std::cout << str << "\n";
     }
 
-    /* Examples:
-    dir:prefix: 1708705259_openmp_distr_monresult
-    */
-    //copy_source_files(dir_prefix, src_files);
     Mitos_copy_sources(dir_prefix, src_files);
-}
-
-void openInputFile (std::ifstream &inputFile, std::string &bin_name, std::string &dir_path,
-            std::string &dir_prefix){
-    std::string line;
-    while (std::getline(inputFile, line)) {
-        // Find the position of '=' character
-        size_t pos = line.find('=');
-        if (pos != std::string::npos) {
-            // Extract variable name and value
-            std::string variableName = line.substr(0, pos);
-            std::string value = line.substr(pos + 1);
-
-            // Remove leading/trailing spaces from variable name and value
-            size_t start = variableName.find_first_not_of(" \t");
-            size_t end = variableName.find_last_not_of(" \t");
-            if (start != std::string::npos && end != std::string::npos)
-                variableName = variableName.substr(start, end - start + 1);
-
-            start = value.find_first_not_of(" \t");
-            end = value.find_last_not_of(" \t");
-            if (start != std::string::npos && end != std::string::npos)
-                value = value.substr(start, end - start + 1);
-
-            // Store values in respective variables
-            if (variableName == "bin_name")
-                bin_name = value;
-            else if (variableName == "dir_path")
-                dir_path = value;
-            else if (variableName == "dir_prefix")
-                dir_prefix = value;
-        }
-    }
 }

--- a/src/mitosoutput.cpp
+++ b/src/mitosoutput.cpp
@@ -680,22 +680,35 @@ int Mitos_copy_sources(const std::string& dir_prefix, const std::set<std::string
     
 
     for (auto& src_file : src_files) {
-        LOG_LOW("mitosoutput.cpp: Mitos_copy_sources(), Copying " << src_file);
+        if(src_file.substr(0,4) == "/usr") continue;
         try {
             // Check if source file exists
             if (!fs::exists(src_file)) {
                 std::cerr << "Source file not accessible: " << src_file << "\n";
             }
 
+            auto temp = path_src_dir;
+            size_t lastSlashPos = path_replacements[src_file].find_last_of('/');
+
+            if (lastSlashPos != std::string::npos) {
+                // Extract the substring up to the last occurrence of '/'
+                temp += path_replacements[src_file].substr(0, lastSlashPos + 1); // Include the '/' in the result
+                std::cout << "\nTemp Path: " << temp << std::endl;
+            }
+
+            if (!fs::exists(temp)) {
+                fs::create_directories(temp);
+            }
+            
+            
             // Copy the file
-            fs::copy(src_file, path_src_dir);
+            fs::copy(src_file, temp);
 
             std::cout << "File copied successfully." << "\n";
         } catch (const std::exception& ex) {
             std::cerr << "Error: " << ex.what() << "\n";
         }   
     }
-    
     LOG_LOW("mitosoutput.cpp: Mitos_copy_sources(), Copied all the files.");
     return 0;
 }

--- a/src/mitosoutput.cpp
+++ b/src/mitosoutput.cpp
@@ -372,10 +372,9 @@ std::ofstream fproc(mout->fname_processed);
 
     return 0;
 #else // USE DYNINST
-
-    std::cout << "mitosoutput.cpp, Mitos_openFile(), bin_name: " << bin_name << "\n";
+    LOG_MEDIUM("mitosoutput.cpp, Mitos_openFile(), bin_name: " << bin_name);
     sym_success = SymtabAPI::Symtab::openFile(symtab_obj,bin_name);
-    std::cout << "mitosoutput.cpp, Mitos_openFile(), sym_success: " << sym_success <<"\n";
+    LOG_MEDIUM("mitosoutput.cpp, Mitos_openFile(), sym_success: " << sym_success);
     if(!sym_success)
     {
         std::cerr << "Mitos: Failed to open Symtab object for " << bin_name << std::endl;
@@ -398,7 +397,7 @@ int Mitos_post_process(const char *bin_name, mitos_output *mout, std::set<std::s
 {
     int err = 0;
     // Open input/output files
-    std::cout <<"mout->fname_raw: " <<mout->fname_raw << "\n";
+    LOG_MEDIUM("mitosoutput.cpp, Mitos_post_process(), mout->fname_raw: " <<mout->fname_raw);
     std::ifstream fraw(mout->fname_raw);
     std::ofstream fproc(mout->fname_processed);
     
@@ -417,7 +416,7 @@ int Mitos_post_process(const char *bin_name, mitos_output *mout, std::set<std::s
     Dyninst::Offset ip;
     std::string line, ip_str;
     int tmp_line = 0;
-    LOG_MEDIUM("mitosoutput.cpp:Mitos_post_process(), reading raw samples...");
+    LOG_MEDIUM("mitosoutput.cpp: Mitos_post_process(), reading raw samples...");
 
     while(std::getline(fraw, line).good())
     {
@@ -518,7 +517,7 @@ int Mitos_merge_files(const std::string& dir_prefix, const std::string& dir_firs
         }
     }
     if(first_dir_found) {
-        LOG_LOW("mitosoutput.cpp:Mitos_merge_files(), First Dir Found, copy Files From " << path_first_dir << " to result folder: ./" << dir_prefix << "result");
+        LOG_LOW("mitosoutput.cpp: Mitos_merge_files(), First Dir Found, copy Files From " << path_first_dir << " to result folder: ./" << dir_prefix << "result");
     }else {
         // error, directory not found
         return 1;
@@ -545,7 +544,7 @@ int Mitos_merge_files(const std::string& dir_prefix, const std::string& dir_firs
             if (dir_entry.path().u8string().rfind("./"+ dir_prefix) == 0
             && dir_entry.path().u8string() != path_first_dir
             && dir_entry.path().u8string() != path_dir_result) {
-                LOG_LOW("mitosoutput.cpp:Mitos_merge_files(), Move Data " << dir_entry.path() << " to Result Folder...");
+                LOG_LOW("mitosoutput.cpp: Mitos_merge_files(), Move Data " << dir_entry.path() << " to Result Folder...");
                 // src file
                 std::string path_samples_src = dir_entry.path().u8string() + "/data/raw_samples.csv";
                 if (fs::exists(path_samples_src)) {
@@ -570,7 +569,7 @@ int Mitos_merge_files(const std::string& dir_prefix, const std::string& dir_firs
         file_samples_out.close();
     }
     // TODO Copy Raw samples
-    std::cout << "Merge successfully completed\n";
+    LOG_LOW("mitosoutput.cpp: Mitos_merge_files(), Merge successfully completed");
     return 0;
 }
 
@@ -579,9 +578,10 @@ int Mitos_copy_sources(const std::string& dir_prefix, const std::set<std::string
     std::string path_dir_result = "./"+ dir_prefix;
     // copy source files
 
-    std::cout << "Copying source files to result folder...\n";
+    LOG_LOW("mitosoutput.cpp: Mitos_copy_sources(), Copying source files to result folder");
     std::string path_src_dir = path_dir_result + "/src";
     for (auto& src_file : src_files) {
+        LOG_LOW("mitosoutput.cpp: Mitos_copy_sources(), Copying " << src_file);
         try {
             // Check if source file exists
             if (!fs::exists(src_file)) {
@@ -597,6 +597,6 @@ int Mitos_copy_sources(const std::string& dir_prefix, const std::set<std::string
         }   
     }
     
-    std::cout << "Merge successfully completed\n";
+    LOG_LOW("mitosoutput.cpp: Mitos_copy_sources(), Copied all the files.");
     return 0;
 }

--- a/src/mitosoutput.cpp
+++ b/src/mitosoutput.cpp
@@ -630,6 +630,55 @@ int Mitos_copy_sources(const std::string& dir_prefix, const std::set<std::string
 
     LOG_LOW("mitosoutput.cpp: Mitos_copy_sources(), Copying source files to result folder");
     std::string path_src_dir = path_dir_result + "/src";
+
+    auto common_prefix = [&]() -> std::pair<std::string, int> {    
+        auto iter = src_files.begin();
+        std::string prefix = ((*iter).substr(0,4) == "/usr" ) ? "" : (*iter);
+        int ans = prefix.length(), n = src_files.size();
+
+        for(auto it = ++iter; it != src_files.end(); ++it){
+            int j = 0;
+            auto temp = *it;
+            if(temp.substr(0,4) == "/usr") continue;
+
+            while(j<temp.length() && temp[j] == prefix[j]) j++;
+            ans = std::min(ans, j);
+        }
+        prefix = prefix.substr(0, ans);
+        std::pair<std::string, int> commonPath;
+        commonPath.first = "";
+        commonPath.second = 0;
+        if(prefix.length() > 1)
+        {
+            size_t lastSlashPos = prefix.find_last_of('/');
+
+            if (lastSlashPos != std::string::npos) {
+                // Extract the substring up to the last occurrence of '/'
+                commonPath.first = prefix.substr(0, lastSlashPos + 1); // Include the '/' in the result
+                commonPath.second = lastSlashPos + 1;
+                std::cout << "\nChopped Path: " << commonPath.first << std::endl;
+                return commonPath;
+            } else {
+                std::cout << "No '/' found in the path." << std::endl;
+                return commonPath;
+            }
+        }
+        return commonPath;
+
+    };
+    auto common_path = common_prefix();
+    std::map <std::string, std::string> path_replacements;
+    for (auto& src_file : src_files) {
+        if(src_file.substr(0,4) == "/usr") continue;
+        path_replacements[src_file] = src_file.substr(common_path.second);
+    }
+
+    for (auto &pair:path_replacements)
+    {
+        std::cout << "Key: " << pair.first << ", Value: " << pair.second << std::endl;
+    }
+    
+
     for (auto& src_file : src_files) {
         LOG_LOW("mitosoutput.cpp: Mitos_copy_sources(), Copying " << src_file);
         try {

--- a/src/mitosoutput.cpp
+++ b/src/mitosoutput.cpp
@@ -503,7 +503,7 @@ int Mitos_merge_files(const std::string& dir_prefix, const std::string& dir_firs
     // delete first folder
     //fs::remove_all(path_first_dir);
 
-    std::string path_samples_dest = path_dir_result + "/data/samples.csv";
+    std::string path_samples_dest = path_dir_result + "/data/raw_samples.csv";
     // check if file exist
     if (fs::exists(path_samples_dest)) {
         std::ofstream file_samples_out;
@@ -516,7 +516,7 @@ int Mitos_merge_files(const std::string& dir_prefix, const std::string& dir_firs
             && dir_entry.path().u8string() != path_dir_result) {
                 LOG_LOW("mitosoutput.cpp:Mitos_merge_files(), Move Data " << dir_entry.path() << " to Result Folder...");
                 // src file
-                std::string path_samples_src = dir_entry.path().u8string() + "/data/samples.csv";
+                std::string path_samples_src = dir_entry.path().u8string() + "/data/raw_samples.csv";
                 if (fs::exists(path_samples_src)) {
                     // copy data
                     std::ifstream file_samples_in(path_samples_src);

--- a/src/mitosrun.cpp
+++ b/src/mitosrun.cpp
@@ -197,7 +197,8 @@ int main(int argc, char **argv)
         dump_samples(); // anything left over
         std::cout << "Command completed! Processing samples..." <<  "\n";
         std::cout << "Bin Name" << argv[cmdarg] <<  "\n";
-        err = Mitos_post_process(argv[cmdarg],&mout);
+        std::set<std::string> src_files;
+        err = Mitos_post_process(argv[cmdarg],&mout, src_files);
         if(err)
             return 1;
         std::cout << "Done!\n";

--- a/src/mitosrun.cpp
+++ b/src/mitosrun.cpp
@@ -199,12 +199,15 @@ int main(int argc, char **argv)
         std::cout << "Bin Name" << argv[cmdarg] <<  "\n";
         std::set<std::string> src_files;
         Mitos_add_offsets("", &mout);
-        err = Mitos_openFile(argv[cmdarg], &mout);
-        if(err)
+        if(Mitos_openFile(argv[cmdarg], &mout))
+        {
+            std::cerr << "Error opening binary file!" << std::endl;
             return 1;
-        err = Mitos_post_process(argv[cmdarg],&mout, src_files);
-        if(err)
+        }
+        if(Mitos_post_process(argv[cmdarg],&mout, src_files)){
+            std::cerr << "Error post processing!" << std::endl;
             return 1;
+        }
         std::cout << "Done!\n";
     }
 

--- a/src/mitosrun.cpp
+++ b/src/mitosrun.cpp
@@ -198,6 +198,10 @@ int main(int argc, char **argv)
         std::cout << "Command completed! Processing samples..." <<  "\n";
         std::cout << "Bin Name" << argv[cmdarg] <<  "\n";
         std::set<std::string> src_files;
+        Mitos_add_offsets("", &mout);
+        err = Mitos_openFile(argv[cmdarg], &mout);
+        if(err)
+            return 1;
         err = Mitos_post_process(argv[cmdarg],&mout, src_files);
         if(err)
             return 1;


### PR DESCRIPTION
This PR rearranges the post-processing and merging of the samples generated using Mitoshooks

The following changes have been made:

While running Mitoshooks:

1. Start the application as usual and initiate the sampling
2. Instead of saving the virtual offset of the binary at one place (`/tmp/virt_address.txt`), save it for every thread using the known prefixes (thread\_id and timestamp) at `/tmp/prefix_thread_id`
3. While each thread saves the samples in `raw_samples.csv,` add another column for the offset (by reading the file generated in step 2. This is done after all the raw samples have been flushed.
4. When all the samples have been written in `raw_samples.csv`  by each thread, combine all the `raw_samples.csv` files in a single `raw_samples.csv` file.

This is followed by running the `demo_post_process`:

1. As all the samples have already been merged in `raw_samples.csv`, read the `raw_samples.csv` in the merged/results directory.
2. Use Dyninst and the saved virtual address offset (in the extra column) to write `samples.csv`
3. Copy the source files.